### PR TITLE
Update "Create account" link so it points to joinmastodon.org instead of mastodon.social

### DIFF
--- a/src/NewDomain.tsx
+++ b/src/NewDomain.tsx
@@ -189,7 +189,7 @@ export const NewDomain: React.FC<{ onDismiss: () => void }> = () => {
           values={{
             a: (f) => (
               <a
-                href="https://mastodon.social/auth/sign_up"
+                href="https://joinmastodon.org/servers"
                 className="text-blurple-500 hover:underline"
               >
                 {f}


### PR DESCRIPTION
closes #5 